### PR TITLE
Add support for logging join, part and quit events

### DIFF
--- a/jt-logger.py
+++ b/jt-logger.py
@@ -89,11 +89,14 @@ HTML = {
 	"index" : '{}: The {} index {}',
 	"action" : '{} * <span class="person">{}</span> {}',
 	"kick" : '{} -!- <span class="kick">{}</span> was kicked from {} by {} [{}]',
+	"join" : '{} <span class="person">{}:has joined</span>',
 	"mode" : '{} -!- {} mode set to <span class="mode">{}</span> by <span class="person">{}</span>',
 	"nick" : '{} <span class="person">{}</span> is now known as <span class="person">{}</span>',
 	"pubmsg" : '{} <span class="person">{}:</span> {}',
 	"pubnotice" : '{} <span class="notice">-{}:{}-</span>{}',
+	"part" : '{} <span class="person">{}:has left</span>{} {}',
 	"topic" : '{} <span class="person">{}</span> changed topic of <span class="channel">{}</span> to: {}',
+	"quit" : '{} <span class="person">{}:has quit</span>',
 }
 
 CHANNEL_HEADER = """<!DOCTYPE html>
@@ -306,7 +309,11 @@ class Logbot(SingleServerIRCBot):
 		date = time.strftime("%Y-%m-%d")
 		hm = time.strftime(TIME_FORMAT)
 		msg = STRIPPED(self.format_html[action])
-		channel = event.target()
+		if action == 'quit':
+			channel = params.get("%chan%")
+		else:
+			channel = event.target()
+
 		if action == 'action': # someone says /me
 			msg = msg.format(hm, self.user(event), cgi.escape(event.arguments()[0]))
 		elif action == 'pubmsg': # public message
@@ -327,6 +334,12 @@ class Logbot(SingleServerIRCBot):
 			msg = msg.format(hm, self.user(event), event.target(), event.arguments()[0])
 		elif action == 'topic': # /topic changed
 			msg = msg.format(hm, self.user(event), event.target(), event.arguments()[0])
+		elif action == 'join': # someone has joined
+			msg = msg.format(hm, self.user(event), event.target())
+		elif action == 'part': # someone has left the channel
+			msg = msg.format(hm, self.user(event), event.target(), event.arguments()[0])
+		elif action == 'quit': # someone has quit
+			msg = msg.format(hm, self.user(event), event.target())
 		self.append_log_msg(date, channel, msg)
 
 	def append_log_msg(self, date, channel, msg):


### PR DESCRIPTION
On setting LOG_JOIN, LOG_PART or LOG_QUIT = True, jt-logger.py crashes.

Added messages to the HTML dict to resolve the following KeyError:

      File "jt-logger.py", line 233, in on_join
            if LOG_JOIN:self.format_event("join", event)
      File "jt-logger.py", line 311, in format_event
            msg = STRIPPED(self.format_html[action])
    KeyError: 'join'

Furthermore, if the action was 'quit', then the event.target was None.
Modified the code for reading the channel name from params for the
following case:

      File "jt-logger.py", line 282, in on_quit
            self.format_event("quit", event, {"%chan%" : chan})
      File "jt-logger.py", line 348, in format_event
            self.append_log_msg(date, channel, msg)
      File "jt-logger.py", line 354, in append_log_msg
            log_path = os.path.join(LOG_FOLDER, channel, date) + '.html'
            File "/usr/lib/python2.7/posixpath.py", line 75, in join
            if b.startswith('/'):
    AttributeError: 'NoneType' object has no attribute 'startswith'